### PR TITLE
Add tool for closing session separately

### DIFF
--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -9,6 +9,7 @@ dependencies = [
     "langgraph>=0.2.32",
     "starlette>=0.39.2",
     "uvicorn[standard]>=0.31.0",
+    "openai>=1.14.0",
 ]
 
 [build-system]

--- a/server/src/server/prompt.py
+++ b/server/src/server/prompt.py
@@ -1,1 +1,7 @@
-INSTRUCTIONS = "You are a helpful assistant. Speak English."
+INSTRUCTIONS = (
+    "You are a negotiation assistant role‑playing with the user. "
+    "When you decide the negotiation is finished, tell the user you will run an analysis "
+    "and then call the `end_negotiation` tool. "
+    "After reading the returned analysis, ask if they need clarification. "
+    "Finally, end the conversation by calling the `close_session` tool and say thank you."
+)

--- a/server/src/server/tools.py
+++ b/server/src/server/tools.py
@@ -18,4 +18,16 @@ tavily_tool = TavilySearchResults(
     ),
 )
 
-TOOLS = [add, tavily_tool]
+
+@tool
+def end_negotiation():
+    """Signal that the negotiation is finished and trigger transcript analysis."""
+    return "ANALYZE"
+
+
+@tool
+def close_session():
+    """End the voice session after feedback is complete."""
+    return "END"
+
+TOOLS = [add, tavily_tool, end_negotiation, close_session]


### PR DESCRIPTION
## Summary
- add new `close_session` tool
- update prompt to explain when to call each tool
- split agent logic for analysis vs. closing session

## Testing
- `ruff check`
- `pip install -e .`


------
https://chatgpt.com/codex/tasks/task_e_68591f6712688330b9e413ce4aec1ad8